### PR TITLE
Remove warnings and update node-addon-api version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   "homepage": "https://github.com/devsnek/node-register-scheme#readme",
   "dependencies": {
     "bindings": "^1.3.0",
-    "node-addon-api": "^1.1.0"
+    "node-addon-api": "^1.2.0"
   }
 }

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -5,7 +5,7 @@ Napi::Value RPH(const Napi::CallbackInfo& info) {
   const char* scheme = info[0].As<Napi::String>().Utf8Value().c_str();
   const char* command = info[0].As<Napi::String>().Utf8Value().c_str();
 
-  Register(scheme, command);
+  return Napi::Boolean::New(info.Env(), Register(scheme, command));
 }
 
 Napi::Object Init(Napi::Env env, Napi::Object exports) {


### PR DESCRIPTION
Hi everyone,
I provided to update the version of **node-addon-api** to 1.2.0 and then I removed the warning obtained on compilation in the RPH native function. 
if it specified that this function have to return value 
```cpp 
Napi::Value RPH(const Napi::CallbackInfo& info)
```
then could be right return a boolean value returned by **Register** function:
```cpp
bool Register(const char* scheme, const char* command);
```
In this way returning a value it will indicate if the register operation was executed or not.
